### PR TITLE
fix a overflow with word-break

### DIFF
--- a/th/public/index.html
+++ b/th/public/index.html
@@ -235,7 +235,7 @@
 
     <div class="footer">
       Ical:
-      <a
+      <a style="word-break: break-word;"
         href="https://calendar.google.com/calendar/ical/tech.cal.th%40gmail.com/public/basic.ics"
         >https://calendar.google.com/calendar/ical/tech.cal.th%40gmail.com/public/basic.ics</a
       >


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5865946/59976180-f2ce4100-95ea-11e9-947f-4e504c190d2e.png)
![image](https://user-images.githubusercontent.com/5865946/59976211-59535f00-95eb-11e9-9efc-36bc224d2c62.png)

In small device, the footer hyperlink is overflow.
