### PR TITLE
Fixed an overflow on event link paragraph

### DIFF
--- a/th/public/index.html
+++ b/th/public/index.html
@@ -167,7 +167,7 @@
       <h1 id="event-header"></h1>
       <p id="event-date"></p>
       <p id="event-location"></p>
-      <p id="event-description"></p>
+      <p id="event-description" style="word-break: break-all;"></p>
       <p id="event-link"></p>
     </dialog>
     <div id="calendar"></div>


### PR DESCRIPTION
Problems:

in chrome on macOS:
![image](https://user-images.githubusercontent.com/6449655/60418676-bb285000-9c0d-11e9-8b0c-313fda78d3d6.png)

PWA on Android:
![image](https://user-images.githubusercontent.com/6449655/60418887-430e5a00-9c0e-11e9-8925-91ba14ac1dc2.png)
